### PR TITLE
Strip extra lines in default item output

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='tasks',
-    version='2.7.1',
+    version='2.8.0',
     author='Paul Baecher',
     description='A simple personal task queue to track todo items',
     long_description=open('README.md').read(),

--- a/tasks/model.py
+++ b/tasks/model.py
@@ -32,7 +32,7 @@ def next_backlog_num(items):
     return next(iter_backlog(items), {'num': 0})['num']
 
 
-def fmt_item(item, color=True, shortcut=None):
+def fmt_item(item, shortcut=None):
     color = {
         events.STATUS_TODO: 'blue',
         events.STATUS_PROGRESS: 'yellow',

--- a/tasks/model.py
+++ b/tasks/model.py
@@ -1,4 +1,5 @@
 from itertools import chain
+from os import linesep
 
 from . import events
 from .color import escape
@@ -45,8 +46,11 @@ def fmt_item(item, shortcut=None):
         '([cyan {}]) '.format(shortcut) if shortcut else '... '
     )
 
+    (title, *body) = item['text'].split(linesep)
+    text = '{}{}'.format(escape(title), ' (…)' if len(body) else '')
+
     return '[gray #{}] {}[{} {}] [white {}]'.format(
-        item['num'], hint, color, item['status'], escape(item['text']))
+        item['num'], hint, color, item['status'], text)
 
 
 def iter_backlog(items):

--- a/tasks/model.py
+++ b/tasks/model.py
@@ -46,7 +46,7 @@ def fmt_item(item, shortcut=None):
         '([cyan {}]) '.format(shortcut) if shortcut else '... '
     )
 
-    (title, *body) = item['text'].split(linesep)
+    title, *body = item['text'].split(linesep, maxsplit=1)
     text = '{}{}'.format(escape(title), ' (…)' if len(body) else '')
 
     return '[gray #{}] {}[{} {}] [white {}]'.format(

--- a/tasks/test/test_model.py
+++ b/tasks/test/test_model.py
@@ -1,0 +1,22 @@
+from ..events import STATUS_PROGRESS, STATUS_TODO
+from ..model import fmt_item
+
+_multiline_text = """buy tomatoes
+1kg should be enough
+Reference: https://en.wikipedia.org/wiki/Tomato
+"""
+
+
+def test_format():
+    item1 = {"num": 1, "text": "buy milk", "status": STATUS_TODO}
+    item2 = {"num": 2, "text": _multiline_text, "status": STATUS_PROGRESS}
+
+    assert fmt_item(item1) == "[gray #1] [blue todo] [white buy milk]"
+    assert (
+        fmt_item(item1, shortcut="a")
+        == "[gray #1] ([cyan a]) [blue todo] [white buy milk]"
+    )
+    assert (
+        fmt_item(item2)
+        == "[gray #2] [yellow progress] [white buy tomatoes (…)]"
+    )


### PR DESCRIPTION
This change is just a suggestion, happy to discuss.

I find myself pretty often wanting to attach more information to each item. But it doesn't play well with the display, currently optimized for 1-line items (both in list view like `backlog` or with a short status line). For this reason I assume that tasks is very rarely used with multiline items.

This allows to add more context when using edit by simply adding more lines, without it being shown in normal operations.